### PR TITLE
Min kanboard version check modified. Kanboard v1.2.x version detected…

### DIFF
--- a/app/src/main/java/in/andres/kandroid/kanboard/KanboardProject.java
+++ b/app/src/main/java/in/andres/kandroid/kanboard/KanboardProject.java
@@ -21,6 +21,7 @@ package in.andres.kandroid.kanboard;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -75,6 +76,15 @@ public class KanboardProject implements Comparable<KanboardProject>, Serializabl
         this(project, null, null, null, null, null, null, null);
     }
 
+    private URL readUrlFromJSON(JSONObject urls, String urlName ) throws MalformedURLException {
+        String url = urls.optString(urlName);
+        URL returnUrl = null;
+        if (!TextUtils.isEmpty(url)){
+            returnUrl = new URL(url);
+        }
+        return returnUrl;
+    }
+
     public KanboardProject(@NonNull JSONObject project, @Nullable JSONArray columns, @Nullable JSONArray swimlanes,
                            @Nullable JSONArray categories, @Nullable JSONArray activetasks,
                            @Nullable JSONArray inactivetasks, @Nullable JSONArray overduetasks,
@@ -108,9 +118,10 @@ public class KanboardProject implements Comparable<KanboardProject>, Serializabl
         NumberActiveTasks = project.optInt("nb_active_tasks");
         JSONObject urls = project.optJSONObject("url");
         if (urls != null) {
-            ListURL = new URL(urls.optString("list"));
-            BoardURL = new URL(urls.optString("board"));
-            CalendarURL = new URL(urls.optString("calendar"));
+            ListURL = readUrlFromJSON(urls,"list");
+            BoardURL = readUrlFromJSON(urls,"board");
+            CalendarURL = readUrlFromJSON(urls,"calendar");
+
         } else {
             ListURL = null;
             BoardURL = null;

--- a/app/src/main/java/in/andres/kandroid/ui/LoginActivity.java
+++ b/app/src/main/java/in/andres/kandroid/ui/LoginActivity.java
@@ -239,9 +239,11 @@ public class LoginActivity extends AppCompatActivity {
                             editor.putString("username", username);
                             editor.putString("password", password);
                             editor.apply();
-                        } else if (version[0] >= Constants.minKanboardVersion[0] &&
-                            version[1] >= Constants.minKanboardVersion[1] &&
-                            version[2] >= Constants.minKanboardVersion[2]) {
+                          } else if (version[0]*10000+version[1]*100+version[2] >=
+                                      Constants.minKanboardVersion[0]*10000
+                                              +Constants.minKanboardVersion[1]*100
+                                              +Constants.minKanboardVersion[2]
+                            ) {
                             SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
                             SharedPreferences.Editor editor = preferences.edit();
                             editor.putString("serverurl", serverurl.trim());
@@ -305,4 +307,3 @@ public class LoginActivity extends AppCompatActivity {
         }
     }
 }
-


### PR DESCRIPTION
… as older than v1.11#

With kanboard 1.2.0, the check of minimun version, blocks connecting to the server for considering "2" minor version number less than 1x versión. This change multiplies every version group number for 10 multiples to compare unique value. Works if every version group has a maximum of 2 numbers.