### PR TITLE
fix version get of v1.2.11

### DIFF
--- a/app/src/main/java/in/andres/kandroid/kanboard/KanboardAPI.java
+++ b/app/src/main/java/in/andres/kandroid/kanboard/KanboardAPI.java
@@ -325,7 +325,7 @@ public class KanboardAPI {
                             tag = res;
                         } else {
                             try {
-                                Pattern regex = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:,(.*)){0,1}$", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+                                Pattern regex = Pattern.compile("^[vV]{0,1}(\\d+)\\.(\\d+)\\.(\\d+)(?:,(.*)){0,1}$", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
                                 Matcher regexMatcher = regex.matcher(res);
                                 if (regexMatcher.find()) {
                                     version[0] = Integer.parseInt(regexMatcher.group(1));


### PR DESCRIPTION
As the return value of getVersion changed to "**v**1.2.11", the related function in KanboardAPI should be fixed accordingly.